### PR TITLE
Fixes bug where -h option would not display full help.

### DIFF
--- a/src/commands/cse.ts
+++ b/src/commands/cse.ts
@@ -1,6 +1,5 @@
 import { Command } from "../extensions";
 import { registerProviders } from "../initialization/registerProviders";
-import { UserUtils } from "../utils";
 import { agile, project, links, playbook } from "./commands";
 
 export const cse = new Command()
@@ -16,9 +15,3 @@ export const cse = new Command()
   .addCommand(playbook)
   .addCommand(project)
   .printHelp();
-
-cse.help(helpText => {
-  return UserUtils.createAsciiArt("CSE").concat("\n", helpText);
-});
-
-cse.parse(process.argv);

--- a/src/commands/cse.ts
+++ b/src/commands/cse.ts
@@ -1,5 +1,6 @@
 import { Command } from "../extensions";
 import { registerProviders } from "../initialization/registerProviders";
+import { UserUtils } from "../utils";
 import { agile, project, links, playbook } from "./commands";
 
 export const cse = new Command()
@@ -8,10 +9,16 @@ export const cse = new Command()
   .initialize(() => {
     registerProviders();
   })
-  .asciiArt("CSE")
+  .addAsciiArt("CSE")
   .passCommandToAction(false)
   .addCommand(agile)
   .addCommand(links)
   .addCommand(playbook)
   .addCommand(project)
   .printHelp();
+
+cse.help(helpText => {
+  return UserUtils.createAsciiArt("CSE").concat("\n", helpText);
+});
+
+cse.parse(process.argv);

--- a/src/extensions/command.test.ts
+++ b/src/extensions/command.test.ts
@@ -107,7 +107,7 @@ describe("Command", () => {
     
     // Act
     new Command()
-      .asciiArt(originalText)
+      .addAsciiArt(originalText)
       .parse(["node.exe", "index.js", "commandName"]);
 
     // Assert

--- a/src/extensions/command.ts
+++ b/src/extensions/command.ts
@@ -1,10 +1,9 @@
-import chalk from "chalk";
 import { Command as CommanderCommand } from "commander";
-import figlet from "figlet";
 import { CseCliConfig } from "../models/config/cliConfig";
 import { Link } from "../models/general/link";
 import { ConfigService } from "../services";
 import { urlCommand } from "./urlCommand";
+import { UserUtils } from "../utils";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ActionHandler = (options: any, config: CseCliConfig) => void|Promise<void>;
@@ -41,9 +40,9 @@ export class Command extends CommanderCommand {
     return this;
   }
 
-  public asciiArt(message: string): Command {
+  public addAsciiArt(message: string): Command {
     this.addAction(() => {
-      console.log(chalk.cyanBright(figlet.textSync(message)));
+      console.log(UserUtils.createAsciiArt(message));
     });
     return this;
   }

--- a/src/utils/userUtils.ts
+++ b/src/utils/userUtils.ts
@@ -1,3 +1,5 @@
+import chalk from "chalk";
+import figlet from "figlet";
 import { createInterface } from "readline";
 
 export class UserUtils {
@@ -18,5 +20,9 @@ export class UserUtils {
       read.close();
       resolve(answer);
     }));
+  }
+
+  public static createAsciiArt(message: string): string {
+    return chalk.cyanBright(figlet.textSync(message));
   }
 }


### PR DESCRIPTION
Previously, running `cse -h` would display the following:

```bash
zach@DESKTOP-LKS7HLF cse-cli % cse -h
Usage: init [options]

Backlog Initialization

Options:
  -h, --help  display help for command
```

Whereas running `cse` would display the following:
```bash
zach@DESKTOP-LKS7HLF cse-cli % cse
   ____ ____  _____ 
  / ___/ ___|| ____|
 | |   \___ \|  _|  
 | |___ ___) | |___ 
  \____|____/|_____|
                    
Usage: cse [options] [command]

CSE Bootstrap CLI

Options:
  -h, --help  display help for command

Commands:
  backlog     Backlog management
  init        Local Configuration Initialization
  playbook    CSE playbook for the way we do work
  links       Open useful links
```

This PR unifies these responses to both use the `cse` output.